### PR TITLE
removed broken[deprecated] Blob syntax from wavetrack.js

### DIFF
--- a/app/js/wavetrack.js
+++ b/app/js/wavetrack.js
@@ -29,11 +29,8 @@ function WaveTrack()
         
         var encodedWave = this.encodeWaveFile();
         
-        var bb = new BlobBuilder();
-        var blob;
-        bb.append(encodedWave.buffer);
-        blob = bb.getBlob(encoding);
-        
+        var blob = new Blob([encodedWave], {type: encoding});
+
         if (asyncMethod !== undefined)
         {
             var fileReader = new FileReader();


### PR DESCRIPTION
Rendering/Saving was not working in Chrome (didn't test other browsers)

Needed to change the 4 lines that generated the new Blob to one line using the new syntax:

```
    var blob = new Blob([encodedWave], {type: encoding});
```
