### PR TITLE
Fix for larger files and Float32Array compatibility

### DIFF
--- a/app/js/audioLayerControl.js
+++ b/app/js/audioLayerControl.js
@@ -290,7 +290,7 @@ function audioLayerControl(elementContext)
             this.paste();
             this.zoomToFit();
         }
-    }
+    };
     
     this.del = function del()
     {
@@ -313,7 +313,7 @@ function audioLayerControl(elementContext)
         
         wave.fromAudioSequences(sequenceList);
         return wave;
-    }
+    };
     
     this.playToggle = function playToggle()
     {
@@ -459,8 +459,8 @@ function audioLayerControl(elementContext)
         {
             $('#app-progress')[0].style['width'] = '50%';
             activeAudioLayerControl = this.eventHost.elementContext;
-            this.eventHost.audioPlayback.audioContext.decodeAudioData(this.resultArrayBuffer, this.eventHost.decodeAudioFinished, this.eventHost.decodeAudioFailed);  
-        }
+            this.eventHost.audioPlayback.audioContext.decodeAudioData(this.resultArrayBuffer, this.eventHost.decodeAudioFinished, this.eventHost.decodeAudioFailed);
+        };
         
         filedb.onFail = function(e)
         {
@@ -486,12 +486,16 @@ function audioLayerControl(elementContext)
               default:
                 msg = 'Unknown Error ' + e.code;
                 break;
-            };
+            }
           
             console.log('Error: ' + msg);
         }  
     };
-    
+
+    this.decodeAudioFailed = function decodeAudioFailed(audioBuffer) {
+        console.log('decodeAudioFailed, audiobuffer=', audioBuffer);
+
+    };
     this.decodeAudioFinished = function decodeAudioFinished(audioBuffer)
     {
         $('#app-progress')[0].style['width'] = '90%';


### PR DESCRIPTION
Hi,

The proposed updates fix:
1. A problem with loading larger audio files (the loop+array.push you used cause browser crash - replacing with array.slice does the trick).
2. A problem with all the editing functions (crashing in audiosequence trim/merge/clone - these functions used methods of array, not TypedArray (and AudioContext returns Float32Array now)).

Thanks for your good work!

Pawel